### PR TITLE
feat: config-driven post-add automation for whq worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ whq.dSYM/
 # macOS
 .DS_Store
 
+issues/

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Post-add (.whq.json): completed
 
 - If automation succeeds the final confirmation line still prints. On failure,
   no summary is printed and the error is surfaced to stderr.
+- When post-add fails, `whq` automatically calls the equivalent of
+  `whq rm -b <branch>` to delete the just-created worktree. The branch is
+  deleted only when it was created by this `whq add` invocation; existing
+  branches are preserved while their failed worktrees are removed.
 
 ### Validation checklist
 

--- a/cmd/whq/cleanup_test.go
+++ b/cmd/whq/cleanup_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCleanupFailedAddRemovesWorktreeAndBranch(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(repoRoot, "wt-feature")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("setup mkdir failed: %v", err)
+	}
+
+	logFile := filepath.Join(repoRoot, "git.log")
+	fakeGitDir := t.TempDir()
+	scriptPath := filepath.Join(fakeGitDir, "git")
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %s
+if [ "$1" = "worktree" ] && [ "$2" = "remove" ]; then
+  exit 0
+fi
+if [ "$1" = "branch" ] && [ "$2" = "-d" ]; then
+  exit 1
+fi
+exit 0
+`, logFile)
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git failed: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", fakeGitDir+string(os.PathListSeparator)+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	if err := cleanupFailedAdd(repoRoot, worktreeRoot, "feature/test", true); err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if _, err := os.Stat(worktreeRoot); !os.IsNotExist(err) {
+		t.Fatalf("expected worktree directory removed, err=%v", err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log failed: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "worktree remove") {
+		t.Fatalf("expected worktree remove command, log=%q", log)
+	}
+	if !strings.Contains(log, "branch -d") || !strings.Contains(log, "branch -D") {
+		t.Fatalf("expected branch deletion attempts, log=%q", log)
+	}
+}
+
+func TestCleanupFailedAddSkipsBranchDeletionWhenNotRequested(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(repoRoot, "wt-existing")
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("setup mkdir failed: %v", err)
+	}
+
+	logFile := filepath.Join(repoRoot, "git.log")
+	fakeGitDir := t.TempDir()
+	scriptPath := filepath.Join(fakeGitDir, "git")
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %s
+exit 0
+`, logFile)
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git failed: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", fakeGitDir+string(os.PathListSeparator)+origPath)
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	if err := cleanupFailedAdd(repoRoot, worktreeRoot, "feature/existing", false); err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log failed: %v", err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "branch") {
+		t.Fatalf("did not expect branch deletion command, log=%q", log)
+	}
+}

--- a/cmd/whq/main.go
+++ b/cmd/whq/main.go
@@ -241,6 +241,10 @@ var addCmd = &cobra.Command{
 			return fmt.Errorf("")
 		}
 
+		if err := runPostAddActions(env.RepoRoot, dest); err != nil {
+			return err
+		}
+
 		fmt.Fprintf(os.Stdout, "Created worktree: %s\n", dest)
 		return nil
 	},

--- a/cmd/whq/post_add.go
+++ b/cmd/whq/post_add.go
@@ -231,3 +231,20 @@ func copyFile(src, dest string, perm fs.FileMode) error {
 	}
 	return nil
 }
+
+func cleanupFailedAdd(repoRoot, worktreeRoot, branch string, removeBranch bool) error {
+	fmt.Fprintf(os.Stderr, "Post-add failed: removing worktree %s\n", worktreeRoot)
+
+	if err := removeWorktree(repoRoot, worktreeRoot, false); err != nil {
+		return fmt.Errorf("whq: cleanup failed while removing worktree: %w", err)
+	}
+	_ = os.RemoveAll(worktreeRoot)
+
+	if removeBranch {
+		fmt.Fprintf(os.Stderr, "Post-add failed: deleting branch %s\n", branch)
+		if err := deleteBranch(repoRoot, branch); err != nil {
+			return fmt.Errorf("whq: cleanup failed while deleting branch: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/whq/post_add.go
+++ b/cmd/whq/post_add.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type whqConfig struct {
+	PostAdd *postAddConfig `json:"post_add"`
+}
+
+type postAddConfig struct {
+	Copy     []string `json:"copy"`
+	Commands []string `json:"commands"`
+}
+
+func runPostAddActions(repoRoot, worktreeRoot string) error {
+	cfg, err := loadWHQConfig(repoRoot)
+	if err != nil {
+		return err
+	}
+	if cfg == nil || cfg.PostAdd == nil {
+		return nil
+	}
+
+	copyTotal := len(cfg.PostAdd.Copy)
+	cmdTotal := len(cfg.PostAdd.Commands)
+	if copyTotal == 0 && cmdTotal == 0 {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stdout, "Post-add (.whq.json): starting (copy=%d, commands=%d)\n", copyTotal, cmdTotal)
+
+	if err := executePostAddCopies(cfg.PostAdd.Copy, repoRoot, worktreeRoot); err != nil {
+		return err
+	}
+	if err := executePostAddCommands(cfg.PostAdd.Commands, worktreeRoot); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(os.Stdout, "Post-add (.whq.json): completed")
+	return nil
+}
+
+func loadWHQConfig(repoRoot string) (*whqConfig, error) {
+	cfgPath := filepath.Join(repoRoot, ".whq.json")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("whq: failed to read .whq.json: %w", err)
+	}
+	var cfg whqConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("whq: invalid .whq.json: %w", err)
+	}
+	return &cfg, nil
+}
+
+func executePostAddCopies(entries []string, repoRoot, worktreeRoot string) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	for _, raw := range entries {
+		item := strings.TrimSpace(raw)
+		if item == "" {
+			return errors.New("whq: post-add copy entry cannot be empty")
+		}
+
+		src, err := safeJoin(repoRoot, item)
+		if err != nil {
+			return fmt.Errorf("whq: invalid post-add copy path %q: %w", item, err)
+		}
+		if _, err := os.Lstat(src); err != nil {
+			return fmt.Errorf("whq: post-add copy source %q not found: %w", item, err)
+		}
+
+		dest, err := safeJoin(worktreeRoot, item)
+		if err != nil {
+			return fmt.Errorf("whq: invalid destination for copy %q: %w", item, err)
+		}
+
+		fmt.Fprintf(os.Stdout, "Post-add copy: %s\n", item)
+		if err := copyPath(src, dest); err != nil {
+			return fmt.Errorf("whq: failed to copy %q: %w", item, err)
+		}
+	}
+	return nil
+}
+
+func executePostAddCommands(commands []string, worktreeRoot string) error {
+	if len(commands) == 0 {
+		return nil
+	}
+	for i, raw := range commands {
+		cmdStr := strings.TrimSpace(raw)
+		if cmdStr == "" {
+			return fmt.Errorf("whq: post-add command %d is empty", i+1)
+		}
+
+		fmt.Fprintf(os.Stdout, "Post-add cmd %d/%d: %s\n", i+1, len(commands), cmdStr)
+		cmd := exec.Command("bash", "-lc", cmdStr)
+		cmd.Dir = worktreeRoot
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("whq: post-add command failed (%s): %w", cmdStr, err)
+		}
+	}
+	return nil
+}
+
+func safeJoin(root, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("path must be relative")
+	}
+	clean := filepath.Clean(rel)
+	if clean == "." || clean == "" {
+		return "", fmt.Errorf("path resolves to root")
+	}
+	if strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+		return "", fmt.Errorf("path escapes repository root")
+	}
+	return filepath.Join(root, clean), nil
+}
+
+func copyPath(src, dest string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return copySymlink(src, dest)
+	}
+	if info.IsDir() {
+		return copyDirectory(src, dest)
+	}
+	return copyFile(src, dest, info.Mode().Perm())
+}
+
+func copySymlink(src, dest string) error {
+	if err := os.RemoveAll(dest); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	target, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	return os.Symlink(target, dest)
+}
+
+func copyDirectory(src, dest string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source is not a directory: %s", src)
+	}
+	if err := os.RemoveAll(dest); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(dest, info.Mode().Perm()); err != nil {
+		return err
+	}
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == src {
+			return nil
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dest, rel)
+		if d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			return os.MkdirAll(target, info.Mode().Perm())
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return copySymlink(path, target)
+		}
+		return copyFile(path, target, info.Mode().Perm())
+	})
+}
+
+func copyFile(src, dest string, perm fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dest); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/whq/post_add_test.go
+++ b/cmd/whq/post_add_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunPostAddActionsCopiesAndCommands(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := t.TempDir()
+
+	writeFile(t, filepath.Join(repoRoot, ".whq.json"), `{
+		"post_add": {
+			"copy": ["configs/app.env", "scripts"],
+			"commands": ["printf 'ready' > ready.txt"]
+		}
+	}`)
+
+	writeFile(t, filepath.Join(repoRoot, "configs", "app.env"), "FOO=bar\n")
+	writeFile(t, filepath.Join(repoRoot, "scripts", "setup.sh"), "#!/bin/sh\necho ok\n")
+
+	if err := runPostAddActions(repoRoot, worktreeRoot); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	gotConfig, err := os.ReadFile(filepath.Join(worktreeRoot, "configs", "app.env"))
+	if err != nil {
+		t.Fatalf("expected copied config file: %v", err)
+	}
+	if string(gotConfig) != "FOO=bar\n" {
+		t.Fatalf("config mismatch: %q", gotConfig)
+	}
+
+	gotScript, err := os.ReadFile(filepath.Join(worktreeRoot, "scripts", "setup.sh"))
+	if err != nil {
+		t.Fatalf("expected copied script: %v", err)
+	}
+	if !strings.Contains(string(gotScript), "echo ok") {
+		t.Fatalf("script mismatch: %q", gotScript)
+	}
+
+	if _, err := os.Stat(filepath.Join(worktreeRoot, "ready.txt")); err != nil {
+		t.Fatalf("expected command output file: %v", err)
+	}
+}
+
+func TestRunPostAddActionsMissingCopy(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := t.TempDir()
+
+	writeFile(t, filepath.Join(repoRoot, ".whq.json"), `{
+		"post_add": {
+			"copy": ["missing.txt"]
+		}
+	}`)
+
+	err := runPostAddActions(repoRoot, worktreeRoot)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestRunPostAddActionsCommandFailure(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := t.TempDir()
+
+	writeFile(t, filepath.Join(repoRoot, ".whq.json"), `{
+		"post_add": {
+			"commands": ["exit 9"]
+		}
+	}`)
+
+	err := runPostAddActions(repoRoot, worktreeRoot)
+	if err == nil || !strings.Contains(err.Error(), "post-add command failed") {
+		t.Fatalf("expected command failure, got %v", err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}

--- a/spec.md
+++ b/spec.md
@@ -41,6 +41,9 @@ Unless otherwise stated, `whq` interacts with the current Git repository only
 - Side effects:
   - `whq add` runs `git worktree add` and thereby triggers standard Git hooks in
     the created worktree.
+  - After `git worktree add` succeeds, the command checks for `.whq.json` in the
+    repository root and, if present, executes the post-add pipeline described
+    below.
 
 ## whq add
 
@@ -56,11 +59,55 @@ Unless otherwise stated, `whq` interacts with the current Git repository only
     existing) the new branch.
 - Options: (none)
 - Output:
-  - On success: `Created worktree: <dest>`.
+  - When `.whq.json` is absent or empty, behavior matches earlier versions:
+    only `Created worktree: <dest>` is printed.
+  - When post-add steps exist, print the following in order:
+    - `Post-add (.whq.json): starting (copy=<n>, commands=<m>)`
+    - One line per copy entry: `Post-add copy: <relative-path>`
+    - One line per command: `Post-add cmd <i>/<total>: <command>`
+    - `Post-add (.whq.json): completed`
+    - `Created worktree: <dest>`
+  - On any post-add failure (missing source, copy error, command exit), abort
+    the sequence, surface the error, and skip the final summary line.
 - Errors:
   - Missing `<branch>`: print `Usage: whq add <branch>` and exit non-zero.
   - Any failure from `git worktree add` should cause a non-zero exit; surface
     Git’s error output.
+  - Post-add failures bubble up with context (e.g., `whq: failed to copy` or
+    `whq: post-add command failed (...)`) and cause the command to exit non-zero.
+
+### Post-add automation (`.whq.json`)
+
+- Location: repository root only. No parent traversal and no environment
+  overrides.
+- Schema:
+
+```json
+{
+  "post_add": {
+    "copy": ["relative/path", "dir/"],
+    "commands": ["pnpm install", "mise run bootstrap"]
+  }
+}
+```
+
+- Copy rules:
+  - Entries are relative paths rooted at the repository root; absolute paths or
+    paths escaping the root cause validation errors.
+  - Files, directories, and symlinks are supported. Directories are copied
+    recursively. Targets in the new worktree are overwritten (`rm -rf` style)
+    before copying.
+- Command rules:
+  - Commands are executed via `bash -lc` with the new worktree root as `cwd`.
+  - Each command inherits stdout/stderr so the user can observe the output.
+- Execution order:
+  1. `git worktree add` finishes successfully.
+  2. Copy entries run sequentially; any failure aborts the pipeline.
+  3. Commands run sequentially; any failure aborts the pipeline.
+  4. Upon success the CLI prints the completion summary followed by
+     `Created worktree: <dest>`.
+- Absence of `.whq.json` or missing `post_add` block results in a silent no-op,
+  preserving the original UX.
 
 ## whq path
 

--- a/spec.md
+++ b/spec.md
@@ -75,6 +75,9 @@ Unless otherwise stated, `whq` interacts with the current Git repository only
     Git’s error output.
   - Post-add failures bubble up with context (e.g., `whq: failed to copy` or
     `whq: post-add command failed (...)`) and cause the command to exit non-zero.
+    When a post-add step fails, the CLI automatically runs the equivalent of
+    `whq rm -b <branch>` to clean up the new worktree; the branch deletion only
+    occurs if the branch was created by this `whq add` execution.
 
 ### Post-add automation (`.whq.json`)
 
@@ -108,6 +111,11 @@ Unless otherwise stated, `whq` interacts with the current Git repository only
      `Created worktree: <dest>`.
 - Absence of `.whq.json` or missing `post_add` block results in a silent no-op,
   preserving the original UX.
+- Failure handling:
+  - If any copy or command step fails, the CLI attempts to remove the newly
+    created worktree via `git worktree remove` and, when the branch was created
+    by this invocation, deletes it using `git branch -d` (fallback `-D`). Errors
+    from the cleanup step are appended to the original failure message.
 
 ## whq path
 


### PR DESCRIPTION
## 概要

`whq add <branch>` 実行後に `.whq.json` の設定に従ってファイルコピーと任意コマンドを自動実行する機能を追加しました。これにより、worktree 作成時の初期化処理を手動で行う必要がなくなります。

## 変更点

- `.whq.json` の `post_add.copy` / `post_add.commands` を読み込み、worktree root で自動実行する機構を実装
- post-add 処理失敗時に worktree/ブランチを自動削除するクリーンアップロジックを追加
- `.whq.json` が存在しない場合は既存動作を維持（silent no-op）
- JSON スキーマリファレンスと使用例を README / spec.md に追記
- ファイルコピー・コマンド実行・エラー分岐を網羅する単体テストを追加

## 動作確認

- リポジトリ root に `.whq.json` を配置し、`whq add test-branch` を実行
- worktree root に指定ファイル/ディレクトリがコピーされることを確認
- `post_add.commands` で指定したコマンドが順次実行されることを確認
- コピー/コマンド実行を意図的に失敗させ、worktree が自動削除されることを確認
- `.whq.json` が存在しない環境で `whq add` が従来通り動作することを確認

## 影響範囲/リスク

`.whq.json` が存在しない場合は既存の挙動を維持するため、既存ユーザーへの影響はありません。post-add 処理の失敗時には自動クリーンアップが行われるため、worktree が中途半端な状態で残るリスクも低減されています。

## 関連/クローズ

Closes #1