### PR TITLE
feat: whq init コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Ensure `git` is available on your `PATH`.
 
 ## Quick Start
 
+- Create the default `.whq.json` template for post-add automation:
+  - `whq init` (use `--force` to overwrite an existing file). The generated
+    `copy`/`commands` arrays are empty so `whq add` keeps its no-op behavior
+    until you customize them.
 - Create a worktree for a branch (creates the branch if it does not exist):
   - `whq add feature-123`
 - Jump to a worktree directory:
@@ -51,6 +55,11 @@ Ensure `git` is available on your `PATH`.
 
 ## Commands
 
+- `whq init [--force]`: Generate a `.whq.json` template in the repository root.
+  - Default template keeps both `copy` and `commands` empty arrays so existing
+    workflows remain unaffected until edited.
+  - When the file already exists, the command aborts without overwriting unless
+    `--force` is specified (stderr explains what was skipped).
 - `whq add <branch>`: Create `repo_whq_root/<branch>` worktree; creates branch
   from HEAD if missing.
 - `whq path <branch|@>`: Print absolute path to a worktree, or `repo_root` for
@@ -97,8 +106,11 @@ See `spec.md` for the full specification and implementation details.
 ## Post-add automation (`.whq.json`)
 
 `whq add` natively supports repository-specific setup steps driven by a JSON
-file in the repo root. When `.whq.json` is missing the behavior is identical to
-previous releases (silent no-op).
+file in the repo root. Run `whq init` once to scaffold the template (add
+`--force` to regenerate). The scaffold keeps both arrays empty so `whq add`
+still behaves exactly like prior versions until you populate the lists. When
+`.whq.json` is missing the behavior is identical to previous releases (silent
+no-op).
 
 ### Schema
 

--- a/cmd/whq/init.go
+++ b/cmd/whq/init.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	initForce bool
+
+	initCmd = &cobra.Command{
+		Use:   "init",
+		Short: "Generate a .whq.json template in the repo root",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return errors.New("Usage: whq init")
+			}
+			return runInit(initForce, os.Stdout, os.Stderr)
+		},
+	}
+)
+
+const defaultWHQTemplate = `{
+  "post_add": {
+    "copy": [],
+    "commands": []
+  }
+}
+`
+
+func init() {
+	initCmd.Flags().BoolVarP(&initForce, "force", "f", false, "Overwrite existing .whq.json")
+}
+
+func runInit(force bool, stdout, stderr io.Writer) error {
+	repoRoot := env.RepoRoot
+	if strings.TrimSpace(repoRoot) == "" {
+		return errors.New("whq: not inside a Git repository")
+	}
+
+	configPath := filepath.Join(repoRoot, ".whq.json")
+	if info, err := os.Stat(configPath); err == nil {
+		if !force {
+			fmt.Fprintln(stderr, ".whq.json already exists; use --force to overwrite")
+			return errors.New("whq: .whq.json already exists (use --force to overwrite)")
+		}
+		if info.IsDir() {
+			return errors.New("whq: .whq.json exists and is a directory")
+		}
+		fmt.Fprintln(stderr, "Overwriting existing .whq.json (--force)")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("whq: failed to inspect .whq.json: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, []byte(defaultWHQTemplate), 0o644); err != nil {
+		return fmt.Errorf("whq: failed to write .whq.json: %w", err)
+	}
+
+	fmt.Fprintln(stdout, "Created .whq.json")
+	return nil
+}

--- a/cmd/whq/init_test.go
+++ b/cmd/whq/init_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunInitCreatesTemplate(t *testing.T) {
+	repo := t.TempDir()
+	origEnv := env
+	env.RepoRoot = repo
+	t.Cleanup(func() { env = origEnv })
+
+	var stdout, stderr bytes.Buffer
+	if err := runInit(false, &stdout, &stderr); err != nil {
+		t.Fatalf("runInit failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repo, ".whq.json"))
+	if err != nil {
+		t.Fatalf(".whq.json not written: %v", err)
+	}
+	if string(data) != defaultWHQTemplate {
+		t.Fatalf("template mismatch: %q", string(data))
+	}
+
+	if !strings.Contains(stdout.String(), "Created .whq.json") {
+		t.Fatalf("stdout missing creation message: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunInitSkipsWhenFileExistsWithoutForce(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".whq.json")
+	if err := os.WriteFile(path, []byte("custom"), 0o644); err != nil {
+		t.Fatalf("write seed file failed: %v", err)
+	}
+	origEnv := env
+	env.RepoRoot = repo
+	t.Cleanup(func() { env = origEnv })
+
+	var stdout, stderr bytes.Buffer
+	err := runInit(false, &stdout, &stderr)
+	if err == nil {
+		t.Fatalf("expected error when file exists")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "already exists") {
+		t.Fatalf("stderr missing skip message: %q", stderr.String())
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read existing file: %v", err)
+	}
+	if string(data) != "custom" {
+		t.Fatalf("existing file should remain untouched: %q", string(data))
+	}
+}
+
+func TestRunInitForceOverwritesExisting(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".whq.json")
+	if err := os.WriteFile(path, []byte("outdated"), 0o600); err != nil {
+		t.Fatalf("write seed file failed: %v", err)
+	}
+	origEnv := env
+	env.RepoRoot = repo
+	t.Cleanup(func() { env = origEnv })
+
+	var stdout, stderr bytes.Buffer
+	if err := runInit(true, &stdout, &stderr); err != nil {
+		t.Fatalf("runInit with force failed: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf(".whq.json not written: %v", err)
+	}
+	if string(data) != defaultWHQTemplate {
+		t.Fatalf("template mismatch: %q", string(data))
+	}
+	if !strings.Contains(stdout.String(), "Created .whq.json") {
+		t.Fatalf("stdout missing creation message: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Overwriting") {
+		t.Fatalf("stderr missing overwrite notice: %q", stderr.String())
+	}
+}

--- a/cmd/whq/main.go
+++ b/cmd/whq/main.go
@@ -45,6 +45,7 @@ var (
 func main() {
 	// Subcommands
 	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(pathCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(lsCmd) // alias

--- a/spec.md
+++ b/spec.md
@@ -45,6 +45,39 @@ Unless otherwise stated, `whq` interacts with the current Git repository only
     repository root and, if present, executes the post-add pipeline described
     below.
 
+## whq init
+
+- Synopsis: `whq init [--force]`
+- Description:
+  - Generates a `.whq.json` template in the repository root using a fixed
+    two-space-indented JSON structure with `post_add.copy` and
+    `post_add.commands` keys. Both arrays start empty so running `whq add`
+    immediately after `whq init` remains a no-op.
+  - The command requires a Git repository context (same preconditions as other
+    subcommands) and operates on `repo_root/.whq.json`.
+  - Template contents:
+
+```json
+{
+  "post_add": {
+    "copy": [],
+    "commands": []
+  }
+}
+```
+- Options:
+  - `-f`, `--force`: Overwrite an existing `.whq.json`.
+- Output:
+  - On success, print `Created .whq.json` to stdout.
+  - When overwriting due to `--force`, also print
+    `Overwriting existing .whq.json (--force)` to stderr.
+  - If the file already exists and `--force` is not provided, print a stderr
+    line explaining that the existing file was kept and exit non-zero.
+- Errors:
+  - Extra arguments: `Usage: whq init`.
+  - Filesystem failures bubble up with context (e.g., `whq: failed to write
+    .whq.json: ...`).
+
 ## whq add
 
 - Synopsis: `whq add <branch>`


### PR DESCRIPTION
## 概要

`whq init` コマンドを実装し、リポジトリ直下に `.whq.json` 設定ファイルの雛形を自動生成できるようにしました。これにより post-add 自動化機能をすぐに試せる状態になります。

## 変更点

- `cmd/whq/init.go`: `whq init` コマンドの実装を追加（`.whq.json` 生成、`--force` フラグ対応、エラーハンドリング）
- `cmd/whq/main.go`: `rootCmd` に `initCmd` を登録
- `cmd/whq/init_test.go`: 単体テストを追加（正常系、既存ファイル検出、強制上書き）
- `README.md`: `whq init` の使用方法と生成される JSON フォーマットを記載
- `spec.md`: `whq init` の仕様詳細（動作条件、`--force` フラグ、エラーケース）を追加

## 動作確認

- Git リポジトリ内で `whq init` を実行し、`.whq.json` が生成されることを確認
- 既存の `.whq.json` がある状態で `whq init` を実行し、上書き禁止エラーが出ることを確認
- `whq init --force` で既存ファイルを強制再生成できることを確認
- 生成された `.whq.json` を使い `whq add` との連携が正常に動作することを確認
- 単体テスト `go test ./cmd/whq/...` が全て pass することを確認

## 影響範囲/リスク

- 新規コマンド追加のため既存機能への影響は最小限
- `.whq.json` が既に存在する場合はデフォルトで保護され、誤上書きリスクを回避
- `--force` フラグは明示的な再生成が必要な場合のみ使用される設計

## 関連/クローズ

Closes #3